### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ You will need a SecurityTrails API key to use this tool. If you're using it for 
 Once you have an API key, install golang, then:
 
 ```
+#Go version > 1.17
+go install -v github.com/hakluke/haktrails@latest
+~/go/bin/haktrails
+
+# Go version < 1.17
+# https://golang.org/doc/go-get-install-deprecation
+
 go get github.com/hakluke/haktrails
 ~/go/bin/haktrails
 ```


### PR DESCRIPTION
After golang 1.17 go get will trigger a error

```bash

go get github.com/hakluke/haktrails
go: downloading github.com/hakluke/haktrails v0.0.0-20211005051347-97ddc71b0a69
go get: installing executables with 'go get' in module mode is deprecated.
	Use 'go install pkg@version' instead.
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'
```

Solution: 

```bash
go install -v github.com/hakluke/haktrails@latest
```