### PR TITLE
Fixed Panic and added support for printing errors - AssociatedIPs

### DIFF
--- a/associatedips.go
+++ b/associatedips.go
@@ -21,6 +21,11 @@ func associatedIPs(work chan string, wg *sync.WaitGroup) {
 func parseAndPrintIPs(body string) {
 	var results map[string]interface{}
 	json.Unmarshal([]byte(body), &results)
+	val, ok := results["records"]
+	// Check if there are records in the request to avoid the interface conversion panic
+	if !ok || val == nil {
+		return
+	}
 	recordInterfaces := results["records"].([]interface{})
 	for _, record := range recordInterfaces {
 		recordMap := record.(map[string]interface{})

--- a/associatedips.go
+++ b/associatedips.go
@@ -1,34 +1,35 @@
 package main
 
 import (
-	"encoding/json"
-	"fmt"
-	"sync"
+        "encoding/json"
+        "fmt"
+        "sync"
 )
 
 func associatedIPs(work chan string, wg *sync.WaitGroup) {
-	defer wg.Done()
-	for text := range work {
-		response := getResponse("GET", "company/"+text+"/associated-ips", "")
-		if output == "list" {
-			parseAndPrintIPs(response)
-		} else {
-			fmt.Println(response)
-		}
-	}
+        defer wg.Done()
+        for text := range work {
+                response := getResponse("GET", "company/"+text+"/associated-ips", "")
+                if output == "list" {
+                        parseAndPrintIPs(response)
+                } else {
+                        fmt.Println(response)
+                }
+        }
 }
 
 func parseAndPrintIPs(body string) {
-	var results map[string]interface{}
-	json.Unmarshal([]byte(body), &results)
-	val, ok := results["records"]
-	// Check if there are records in the request to avoid the interface conversion panic
-	if !ok || val == nil {
-		return
-	}
-	recordInterfaces := results["records"].([]interface{})
-	for _, record := range recordInterfaces {
-		recordMap := record.(map[string]interface{})
-		fmt.Println(recordMap["cidr"].(string))
-	}
+        var results map[string]interface{}
+        json.Unmarshal([]byte(body), &results)
+        val, ok := results["records"]
+        // Check if there are records in the request to avoid the interface conversion panic
+        if !ok || val == nil {
+                fmt.Println(body)
+                return
+        }
+        recordInterfaces := results["records"].([]interface{})
+        for _, record := range recordInterfaces {
+                recordMap := record.(map[string]interface{})
+                fmt.Println(recordMap["cidr"].(string))
+        }
 }

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/jordanpotti/haktrails
+module github.com/hakluke/haktrails
 
 go 1.16
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/hakluke/haktrails
+module github.com/jordanpotti/haktrails
 
 go 1.16
 

--- a/utilities.go
+++ b/utilities.go
@@ -1,57 +1,58 @@
 package main
 
 import (
-	"encoding/json"
-	"io/ioutil"
-	"log"
-	"net/http"
-	"strings"
+        "encoding/json"
+        "io/ioutil"
+        "log"
+        "net/http"
+        "strings"
 )
 
 // get a response from an endpoint as a string
 func getResponse(method string, url string, postBody string) string {
-	for {
-		response := tryRequest(method, url, postBody)
-		errorEncountered, message := checkJSONError(response)
-		if errorEncountered {
-			return "JSON error: " + message
-		} else {
-			return string(response)
-		}
-	}
+        for {
+                response, status := tryRequest(method, url, postBody)
+                errorEncountered, message := checkJSONError(response, status)
+                if errorEncountered {
+                        return "JSON error: " + message
+                } else {
+                        return string(response)
+                }
+        }
 }
 
-func tryRequest(method string, url string, postBody string) string {
-	client := &http.Client{}
-	url = apiEndpoint + url
-	req, err := http.NewRequest(method, url, strings.NewReader(postBody))
-	if err != nil {
-		log.Println("Error creating request:", err)
-		return ""
-	}
-	req.Header.Set("apikey", config.SecurityTrails.Key)
-	resp, err := client.Do(req)
+func tryRequest(method string, url string, postBody string) (string, int) {
+        client := &http.Client{}
+        url = apiEndpoint + url
+        req, err := http.NewRequest(method, url, strings.NewReader(postBody))
+        if err != nil {
+                log.Println("Error creating request:", err)
+                return "", 0
+        }
+        req.Header.Set("apikey", config.SecurityTrails.Key)
+        resp, err := client.Do(req)
 
-	if err != nil {
-		log.Println("Error retrieving:", url, err)
-		return ""
-	}
+        if err != nil {
+                log.Println("Error retrieving:", url, err)
+                return "", 0
+        }
+        defer resp.Body.Close()
+        body, err := ioutil.ReadAll(resp.Body)
 
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		log.Println("Error reading request body.", err)
-		return ""
-	}
+        if err != nil {
+                log.Println("Error reading request body.", err)
+                return "", 0
+        }
 
-	return string(body)
+        return string(body), resp.StatusCode
 }
 
 // Checks for {"message":"API rate limit exceeded"} or similar
-func checkJSONError(body string) (bool, string) {
-	var results map[string]string
-	err := json.Unmarshal([]byte(body), &results)
-	if err != nil {
-		return false, ""
-	}
-	return true, results["message"]
+func checkJSONError(body string, status int) (bool, string) {
+        var results map[string]string
+        err := json.Unmarshal([]byte(body), &results)
+        if (err != nil && status == 200) {
+                return false, ""
+        }
+        return true, results["message"]
 }


### PR DESCRIPTION
When running the associated IP's command, if your SecurityTrails subscription didn't support that feature, this tool crashed. I pulled a fix from commit #79fcb965aec519c6e4dba0b9d630eab189cfa913 and place it in associatedips.go.

I also added support in utilities.go to grab the response code to be used for validating that the request was valid (response 200).

I also added a defer to close the http request once we are done with it. 