### PR TITLE
Fix - Support new  securitytrails API response

### DIFF
--- a/subdomains.go
+++ b/subdomains.go
@@ -39,6 +39,6 @@ func parseAndPrintSubdomains(body string, domain string) {
 	}
 	subdomainInterfaces := results["subdomains"].([]interface{})
 	for _, subdomain := range subdomainInterfaces {
-		fmt.Println(subdomain.(string) + "." + domain)
+		fmt.Println(subdomain.(string))
 	}
 }


### PR DESCRIPTION
Securitytrails changed their API. It now returns the full DNS name, not the subdomain name.

Since haktrails concats the subdomain with root domain, the output looks like this:

```
hackerone.com.hackerone.com
api.hackerone.com.hackerone.com
docs.hackerone.com.hackerone.com
support.hackerone.com.hackerone.com
defcon.hackerone.com.hackerone.com
mta-sts.managed.hackerone.com.hackerone.com
web-seo-content-for-business.theflyingkick.websitedesignresource.api.hackerone.com.hackerone.com
zendesk1.hackerone.com.hackerone.com
zendesk2.hackerone.com.hackerone.com
a.ns.hackerone.com.hackerone.com
resources.hackerone.com.hackerone.com
fwdkim1.hackerone.com.hackerone.com
fsdkim.hackerone.com.hackerone.com
email.gh-mail.hackerone.com.hackerone.com
mta-sts.forwarding.hackerone.com.hackerone.com
design.hackerone.com.hackerone.com
events.hackerone.com.hackerone.com
zendesk4.hackerone.com.hackerone.com
zendesk3.hackerone.com.hackerone.com
gslink.hackerone.com.hackerone.com
b.ns.hackerone.com.hackerone.com
www.hackerone.com.hackerone.com
mta-sts.hackerone.com.hackerone.com

```

This PR fixes this issue.