### PR TITLE
Revert Fix to match sectrails API

### DIFF
--- a/subdomains.go
+++ b/subdomains.go
@@ -39,6 +39,6 @@ func parseAndPrintSubdomains(body string, domain string) {
 	}
 	subdomainInterfaces := results["subdomains"].([]interface{})
 	for _, subdomain := range subdomainInterfaces {
-		fmt.Println(subdomain.(string))
+		fmt.Println(subdomain.(string) + "." + domain)
 	}
 }


### PR DESCRIPTION
Securitytrails have changed their API once again and are now using the old format. The [last PR](https://github.com/hakluke/haktrails/pull/14) should be reverted.