### PR TITLE
static http methods replaced with `http.Method(Get/Post)`

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/haktrails.iml
+++ b/.idea/haktrails.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="Go" enabled="true" />
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/haktrails.iml" filepath="$PROJECT_DIR$/.idea/haktrails.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/associateddomains.go
+++ b/associateddomains.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"strconv"
 	"sync"
 )
@@ -22,7 +23,7 @@ func associatedDomains(work chan string, wg *sync.WaitGroup) {
 }
 
 func printAllPages(domain string) {
-	response := getResponse("GET", "domain/"+domain+"/associated", "")
+	response := getResponse(http.MethodGet, "domain/"+domain+"/associated", "")
 	var results map[string]interface{}
 	json.Unmarshal([]byte(response), &results)
 	metaInterface, ok := results["meta"].(map[string]interface{})

--- a/associatedips.go
+++ b/associatedips.go
@@ -1,35 +1,36 @@
 package main
 
 import (
-        "encoding/json"
-        "fmt"
-        "sync"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
 )
 
 func associatedIPs(work chan string, wg *sync.WaitGroup) {
-        defer wg.Done()
-        for text := range work {
-                response := getResponse("GET", "company/"+text+"/associated-ips", "")
-                if output == "list" {
-                        parseAndPrintIPs(response)
-                } else {
-                        fmt.Println(response)
-                }
-        }
+	defer wg.Done()
+	for text := range work {
+		response := getResponse(http.MethodGet, "company/"+text+"/associated-ips", "")
+		if output == "list" {
+			parseAndPrintIPs(response)
+		} else {
+			fmt.Println(response)
+		}
+	}
 }
 
 func parseAndPrintIPs(body string) {
-        var results map[string]interface{}
-        json.Unmarshal([]byte(body), &results)
-        val, ok := results["records"]
-        // Check if there are records in the request to avoid the interface conversion panic
-        if !ok || val == nil {
-                fmt.Println(body)
-                return
-        }
-        recordInterfaces := results["records"].([]interface{})
-        for _, record := range recordInterfaces {
-                recordMap := record.(map[string]interface{})
-                fmt.Println(recordMap["cidr"].(string))
-        }
+	var results map[string]interface{}
+	json.Unmarshal([]byte(body), &results)
+	val, ok := results["records"]
+	// Check if there are records in the request to avoid the interface conversion panic
+	if !ok || val == nil {
+		fmt.Println(body)
+		return
+	}
+	recordInterfaces := results["records"].([]interface{})
+	for _, record := range recordInterfaces {
+		recordMap := record.(map[string]interface{})
+		fmt.Println(recordMap["cidr"].(string))
+	}
 }

--- a/company.go
+++ b/company.go
@@ -2,13 +2,14 @@ package main
 
 import (
 	"fmt"
+	"net/http"
 	"sync"
 )
 
 func company(work chan string, wg *sync.WaitGroup) {
 	defer wg.Done()
 	for text := range work {
-		response := getResponse("GET", "company/"+text, "")
+		response := getResponse(http.MethodGet, "company/"+text, "")
 		fmt.Println(response)
 	}
 }

--- a/details.go
+++ b/details.go
@@ -2,13 +2,14 @@ package main
 
 import (
 	"fmt"
+	"net/http"
 	"sync"
 )
 
 func details(work chan string, wg *sync.WaitGroup) {
 	defer wg.Done()
 	for text := range work {
-		response := getResponse("GET", "domain/"+text, "")
+		response := getResponse(http.MethodGet, "domain/"+text, "")
 		fmt.Println(response)
 	}
 }

--- a/dsl.go
+++ b/dsl.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net/http"
 	"os"
 	"strconv"
 )
@@ -23,7 +24,7 @@ func dsl(query string) {
 		os.Exit(1)
 	}
 	queryString := string(queryJSON)
-	response := getResponse("POST", "prototype/dslv2", queryString)
+	response := getResponse(http.MethodPost, "prototype/dslv2", queryString)
 	var results map[string]interface{}
 	json.Unmarshal([]byte(response), &results)
 	metaInterface, ok := results["meta"].(map[string]interface{})
@@ -40,7 +41,7 @@ func dsl(query string) {
 	fmt.Println(response)                                // print the first page
 	// print all the other pages
 	for i := 2; i <= int(totalPages); i++ {
-		response = getResponse("POST", "prototype/dslv2?page="+strconv.Itoa(i), queryString)
+		response = getResponse(http.MethodPost, "prototype/dslv2?page="+strconv.Itoa(i), queryString)
 		fmt.Println(response)
 	}
 }

--- a/historicaldns.go
+++ b/historicaldns.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"strconv"
 	"sync"
 )
@@ -15,7 +16,7 @@ func historicaldns(work chan string, wg *sync.WaitGroup, lookupType string) {
 }
 
 func printAllPagesHistoricalDNS(domain string, lookupType string) {
-	response := getResponse("GET", "history/"+domain+"/dns/"+lookupType, "")
+	response := getResponse(http.MethodGet, "history/"+domain+"/dns/"+lookupType, "")
 	var results map[string]interface{}
 	json.Unmarshal([]byte(response), &results)
 	maxPage, ok := results["pages"].(float64) // total number of pages
@@ -27,7 +28,7 @@ func printAllPagesHistoricalDNS(domain string, lookupType string) {
 	fmt.Println(response) // print the first page
 	// now print all the other pages
 	for i := 2; i <= int(maxPage); i++ {
-		response = getResponse("GET", "history/"+domain+"/dns/"+lookupType+"/?page="+strconv.Itoa(i), "")
+		response = getResponse(http.MethodGet, "history/"+domain+"/dns/"+lookupType+"/?page="+strconv.Itoa(i), "")
 		fmt.Println(response)
 	}
 }

--- a/historicalwhois.go
+++ b/historicalwhois.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"strconv"
 	"sync"
 )
@@ -15,7 +16,7 @@ func historicalwhois(work chan string, wg *sync.WaitGroup) {
 }
 
 func printAllPagesHistoricalWhois(domain string) {
-	response := getResponse("GET", "history/"+domain+"/whois", "")
+	response := getResponse(http.MethodGet, "history/"+domain+"/whois", "")
 	var results map[string]interface{}
 	json.Unmarshal([]byte(response), &results)
 	maxPage, ok := results["pages"].(float64) // total number of pages
@@ -27,7 +28,7 @@ func printAllPagesHistoricalWhois(domain string) {
 	fmt.Println(response) // print the first page
 	// now print all the other pages
 	for i := 2; i <= int(maxPage); i++ {
-		response = getResponse("GET", "history/"+domain+"/whois/?page="+strconv.Itoa(i), "")
+		response = getResponse(http.MethodGet, "history/"+domain+"/whois/?page="+strconv.Itoa(i), "")
 		fmt.Println(response)
 	}
 }

--- a/ping.go
+++ b/ping.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"fmt"
+	"net/http"
 )
 
 func ping() {
-	response := getResponse("GET", "/ping", "")
+	response := getResponse(http.MethodGet, "/ping", "")
 	fmt.Println(response)
 }

--- a/subdomains.go
+++ b/subdomains.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"sync"
 )
 
@@ -16,7 +17,7 @@ func subdomains(work chan string, wg *sync.WaitGroup) {
 
 // get the subdomains + print them
 func retrieveAndPrintSubdomains(domain string) {
-	response := getResponse("GET", "domain/"+domain+"/subdomains", "")
+	response := getResponse(http.MethodGet, "domain/"+domain+"/subdomains", "")
 	if output == "json" {
 		fmt.Println(response)
 	} else {

--- a/submit.go
+++ b/submit.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"net/http"
 	"sync"
 )
 
@@ -33,5 +34,5 @@ func submitSubdomains(subs []string) {
 	}
 
 	// send it
-	fmt.Println(getResponse("POST", "submit/hostnames", postBody))
+	fmt.Println(getResponse(http.MethodPost, "submit/hostnames", postBody))
 }

--- a/tags.go
+++ b/tags.go
@@ -2,13 +2,14 @@ package main
 
 import (
 	"fmt"
+	"net/http"
 	"sync"
 )
 
 func tags(work chan string, wg *sync.WaitGroup) {
 	defer wg.Done()
 	for text := range work {
-		response := getResponse("GET", "domain/"+text+"/tags", "")
+		response := getResponse(http.MethodGet, "domain/"+text+"/tags", "")
 		fmt.Println(response)
 	}
 }

--- a/usage.go
+++ b/usage.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"net/http"
 
 	"github.com/fatih/color"
 )
@@ -10,7 +11,7 @@ func usage() {
 
 	//color start
 	color.Set(color.FgYellow)
-	response := getResponse("GET", "account/usage", "")
+	response := getResponse(http.MethodGet, "account/usage", "")
 	fmt.Println(response)
 	//color stop
 	color.Unset()

--- a/whois.go
+++ b/whois.go
@@ -2,13 +2,14 @@ package main
 
 import (
 	"fmt"
+	"net/http"
 	"sync"
 )
 
 func whois(work chan string, wg *sync.WaitGroup) {
 	defer wg.Done()
 	for text := range work {
-		response := getResponse("GET", "domain/"+text+"/whois", "")
+		response := getResponse(http.MethodGet, "domain/"+text+"/whois", "")
 		fmt.Println(response)
 	}
 }


### PR DESCRIPTION
Hi,

I've made a simple update in this pull request by replacing the static string "GET" and "POST" with the constant `http.Method(Get/Post)`. This change enhances code readability and maintainability, making it easier to understand that we're using the HTTP GET method.

Thank you. 